### PR TITLE
Fix #17 Add column boundaries for term 1224

### DIFF
--- a/src/main/java/com/keenant/madgrades/CommandLineApp.java
+++ b/src/main/java/com/keenant/madgrades/CommandLineApp.java
@@ -171,10 +171,15 @@ public class CommandLineApp {
     Term term = reports.getOrCreateTerm(termCode);
 
     List<Float> dirColumns = Constants.DIR_COLUMNS;
+    List<Float> gradeColumns = Constants.GRADES_COLUMNS;
     if (termCode == 1124) {
       dirColumns = Constants.DIR_COLUMNS_1124;
     } else if (termCode >= 1204) {
       dirColumns = Constants.DIR_COLUMNS_SINCE_1204;
+    }
+
+    if (termCode == 1224) {
+      gradeColumns = Constants.GRADES_COLUMNS_1224;
     }
 
     // dir report
@@ -186,7 +191,7 @@ public class CommandLineApp {
     // grade report
     InputStream grades = new FileInputStream(gradePath);
     try (Stream<PdfRow> gradeRows = Pdfs
-        .extractRows(grades, Constants.GRADES_COLUMNS, "TERM", false)) {
+        .extractRows(grades, gradeColumns, "TERM", false)) {
       term.addGrades(gradeRows.flatMap(Parse::gradeEntry));
     }
   }

--- a/src/main/java/com/keenant/madgrades/Constants.java
+++ b/src/main/java/com/keenant/madgrades/Constants.java
@@ -14,6 +14,12 @@ public class Constants {
       460, 480, 510, 540, 560, 580, 610, 630, 660, 690
   ).mapToObj(i -> (float) i).collect(Collectors.toList());
 
+  /** columns for "Percentage Distribution of Grades" PDF's specifically for 1224 */
+  public static final List<Float> GRADES_COLUMNS_1224 = IntStream.of(
+      200, 215, 238, 280, 307, 332, 358, 382, 408, 432,
+      459, 482, 508, 537, 560, 584, 608, 634, 660, 686
+  ).mapToObj(i -> (float) i).collect(Collectors.toList());
+
   /** columns for "Final DIR" PDF's https://registrar.wisc.edu/current-reports/ found through trial and error */
   public static final List<Float> DIR_COLUMNS = IntStream.of(
       55, 80, 95, 130, 150, 210, 295, 360, 420, 480, 550


### PR DESCRIPTION
This commit adds boundaries for the columns in the grades report for term 1224. This fixes the issue that was causing the 1224 grade report to be incorrectly parsed.

Fixes #17 