### PR TITLE
Swap incorrectly-named Subject data fields

### DIFF
--- a/src/main/java/com/keenant/madgrades/data/CourseOffering.java
+++ b/src/main/java/com/keenant/madgrades/data/CourseOffering.java
@@ -30,7 +30,7 @@ public class CourseOffering {
     this.termCode = termCode;
     this.courseNumber = courseNumber;
     this.subjects = new HashMap<String, Subject>() {{
-      put(subject.getCode(), subject);
+      put(subject.getName(), subject);
     }};
     this.sections = sections;
     this.name = new AtomicReference<>(name);
@@ -110,7 +110,7 @@ public class CourseOffering {
   }
 
   public void addSubject(Subject subject) {
-    subjects.put(subject.getCode(), subject);
+    subjects.put(subject.getName(), subject);
   }
 
   private void addGrades(int sectionNumber, Map<GradeType, Integer> distribution) {

--- a/src/main/java/com/keenant/madgrades/data/Subject.java
+++ b/src/main/java/com/keenant/madgrades/data/Subject.java
@@ -3,26 +3,26 @@ package com.keenant.madgrades.data;
 import java.util.Objects;
 
 public class Subject {
-  private final String name;
-  private final String abbreviation;
   private final String code;
+  private final String abbreviation;
+  private final String name;
 
-  public Subject(String name, String abbreviation, String code) {
-    this.name = name;
-    this.abbreviation = abbreviation;
+  public Subject(String code, String abbreviation, String name) {
     this.code = code;
+    this.abbreviation = abbreviation;
+    this.name = name;
   }
 
-  public String getName() {
-    return name;
+  public String getCode() {
+    return code;
   }
 
   public String getAbbreviation() {
     return abbreviation;
   }
 
-  public String getCode() {
-    return code;
+  public String getName() {
+    return name;
   }
 
   @Override
@@ -34,13 +34,13 @@ public class Subject {
       return false;
     }
     Subject subject = (Subject) o;
-    return Objects.equals(name, subject.name) &&
+    return Objects.equals(code, subject.code) &&
         Objects.equals(abbreviation, subject.abbreviation) &&
-        Objects.equals(code, subject.code);
+        Objects.equals(name, subject.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, abbreviation, code);
+    return Objects.hash(code, abbreviation, name);
   }
 }

--- a/src/main/java/com/keenant/madgrades/data/Term.java
+++ b/src/main/java/com/keenant/madgrades/data/Term.java
@@ -53,7 +53,7 @@ public class Term {
     for (String subjectCode : subjectCodes) {
       String name = subjectNames.get(subjectCode);
       String abbrev = subjectAbbrevs.get(subjectCode);
-      subjects.put(subjectCode, new Subject(name, abbrev, subjectCode));
+      subjects.put(subjectCode, new Subject(subjectCode, abbrev, name));
     }
 
     Set<Integer> courseNumbers = courseNumbers().collect(Collectors.toSet());

--- a/src/main/java/com/keenant/madgrades/data/TermReports.java
+++ b/src/main/java/com/keenant/madgrades/data/TermReports.java
@@ -65,8 +65,8 @@ public class TermReports {
         tables.put("course_offerings", Mappers.COURSE_OFFERING.map(offering, course));
 
         for (Subject subject : offering.getSubjects()) {
-          subjects.put(subject.getCode(), subject);
-          tables.put("subject_memberships", Mappers.SUBJECT_MEMBERSHIP.map(subject.getCode(), offering));
+          subjects.put(subject.getName(), subject);
+          tables.put("subject_memberships", Mappers.SUBJECT_MEMBERSHIP.map(subject.getName(), offering));
         }
 
         for (Entry<Integer, Map<GradeType, Integer>> grades : offering.getGrades().entrySet()) {
@@ -107,7 +107,7 @@ public class TermReports {
     }
 
     for (Subject subject : scrapedSubjects) {
-      subjects.put(subject.getCode(), subject);
+      subjects.put(subject.getName(), subject);
     }
 
     for (Subject subject : subjects.values()) {

--- a/src/main/java/com/keenant/madgrades/utils/Scrapers.java
+++ b/src/main/java/com/keenant/madgrades/utils/Scrapers.java
@@ -24,11 +24,11 @@ public class Scrapers {
         for (Element tr : tbody.select("tr")) {
             Elements children = tr.children();
 
-            String name = children.get(0).text();
+            String code = children.get(0).text();
             String abbreviation = children.get(1).text();
-            String code = children.get(2).text();
+            String name = children.get(2).text();
 
-            subjects.add(new Subject(name, abbreviation, code));
+            subjects.add(new Subject(code, abbreviation, name));
         }
 
         return subjects;


### PR DESCRIPTION
Initially, the name and code Subject data fields were incorrectly named as vice versa (i.e., code -> name, name -> code). So, I swapped these two fields to its correct value for proper readability. 

This doesn't produce any noticeable breaking changes after doing some small tests with grade reports, but I am not 100% sure if everything works as intended. Theoretically, everything should work fine.